### PR TITLE
feat(cluster): inject custom Node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7831,6 +7831,7 @@ dependencies = [
  "arc-swap",
  "backoff",
  "derivative",
+ "derive-where",
  "derive_more 1.0.0",
  "fpe",
  "futures",

--- a/crates/cluster/Cargo.toml
+++ b/crates/cluster/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 derive_more = { workspace = true, features = ["try_from", "into"] }
+derive-where = { workspace = true }
 derivative = { workspace = true }
 libp2p = { workspace = true }
 itertools = { workspace = true }

--- a/crates/cluster/src/node.rs
+++ b/crates/cluster/src/node.rs
@@ -23,6 +23,13 @@ pub struct Node {
     pub addr: SocketAddrV4,
 }
 
+impl Node {
+    /// Creates a new [`Node`].
+    pub fn new(addr: SocketAddrV4, peer_id: PeerId) -> Self {
+        Self { peer_id, addr }
+    }
+}
+
 // NOTE: The on-chain serialization is non self-describing!
 // This `struct` can not be changed, a `struct` with a new schema version should
 // be created instead.

--- a/crates/cluster/src/task.rs
+++ b/crates/cluster/src/task.rs
@@ -2,21 +2,21 @@ use {
     crate::{
         keyspace,
         node_operator,
-        smart_contract,
+        smart_contract::{self, Read as _},
         view,
+        Config,
+        Event,
         Inner,
         Keyspace,
-        SerializedEvent,
-        View,
     },
     futures::{Stream, StreamExt},
     std::{pin::pin, sync::Arc, time::Duration},
     tokio::sync::watch,
 };
 
-pub(super) struct Task<SC, Shards, Events> {
+pub(super) struct Task<C: Config, Events> {
     pub initial_events: Option<Events>,
-    pub inner: Arc<Inner<SC, Shards>>,
+    pub inner: Arc<Inner<C>>,
     pub watch: watch::Sender<()>,
 }
 
@@ -29,12 +29,10 @@ impl Drop for Guard {
     }
 }
 
-impl<SC, Shards, Events> Task<SC, Shards, Events>
+impl<C: Config, Events> Task<C, Events>
 where
-    SC: smart_contract::Read,
-    Shards: Clone + Send + Sync + 'static,
-    Events: Stream<Item = smart_contract::ReadResult<SerializedEvent>> + Send + 'static,
-    Keyspace: keyspace::sealed::Calculate<Shards>,
+    Events: Stream<Item = smart_contract::ReadResult<Event>> + Send + 'static,
+    Keyspace: keyspace::sealed::Calculate<C::KeyspaceShards>,
 {
     pub(super) fn spawn(self) -> Guard {
         let guard = Guard(tokio::spawn(self.run()));
@@ -67,9 +65,9 @@ where
     async fn update_view(&mut self) -> Result<()> {
         let events = self.inner.smart_contract.events().await?;
 
-        let new_view = View::fetch(&self.inner.smart_contract).await?;
+        let new_view = self.inner.smart_contract.cluster_view().await?;
         if self.inner.view.load().cluster_version != new_view.cluster_version {
-            let new_view = Arc::new(new_view.calculate_keyspace().await);
+            let new_view = Arc::new(crate::View::from_sc(&self.inner.config, new_view).await?);
             self.inner.view.store(new_view);
             let _ = self.watch.send(());
         }
@@ -80,16 +78,17 @@ where
     #[allow(clippy::needless_pass_by_ref_mut)] // otherwise `Steam` is required to be `Sync`
     async fn apply_events(
         &mut self,
-        events: impl Stream<Item = smart_contract::ReadResult<SerializedEvent>>,
+        events: impl Stream<Item = smart_contract::ReadResult<Event>>,
     ) -> Result<()> {
         let mut events = pin!(events);
 
         while let Some(res) = events.next().await {
-            let event = res?.deserialize()?;
+            let event = res?;
             tracing::info!(?event, "received");
 
+            let cfg = &self.inner.config;
             let view = self.inner.view.load_full();
-            let view = Arc::new((*view).clone().apply_event(event).await?);
+            let view = Arc::new((*view).clone().apply_event(&cfg, event).await?);
             self.inner.view.store(view);
             let _ = self.watch.send(());
         }

--- a/crates/cluster/src/view.rs
+++ b/crates/cluster/src/view.rs
@@ -10,41 +10,37 @@ use {
         node_operators,
         settings,
         smart_contract,
+        Config,
         Event,
         Keyspace,
         Maintenance,
         Migration,
+        NodeOperator,
         NodeOperators,
         Ownership,
         Settings,
     },
+    derive_where::derive_where,
     futures::future::OptionFuture,
     std::sync::Arc,
 };
 
 /// Read-only view of a WCN cluster.
-#[derive(Clone)]
-pub struct View<Shards = (), OperatorData = node_operator::Data> {
-    pub(super) node_operators: NodeOperators<OperatorData>,
+#[derive_where(Clone)]
+pub struct View<C: Config> {
+    pub(super) node_operators: NodeOperators<NodeOperator<C::Node>>,
 
     pub(super) ownership: Ownership,
     pub(super) settings: Settings,
 
-    pub(super) keyspace: Arc<Keyspace<Shards>>,
-    pub(super) migration: Option<Migration<Shards>>,
+    pub(super) keyspace: Arc<Keyspace<C::KeyspaceShards>>,
+    pub(super) migration: Option<Migration<C::KeyspaceShards>>,
     pub(super) maintenance: Option<Maintenance>,
 
     pub(super) cluster_version: cluster::Version,
 }
 
-impl<Shards> View<Shards> {
-    pub(super) async fn fetch(contract: &impl smart_contract::Read) -> Result<View, FetchError>
-    where
-        Keyspace: keyspace::sealed::Calculate<Shards>,
-    {
-        Ok(contract.cluster_view().await?.deserialize()?)
-    }
-
+impl<C: Config> View<C> {
     /// Returns [`Ownership`] of the WCN cluster.
     pub fn ownership(&self) -> &Ownership {
         &self.ownership
@@ -56,12 +52,12 @@ impl<Shards> View<Shards> {
     }
 
     /// Returns the primary [`Keyspace`] of the WCN cluster.
-    pub fn keyspace(&self) -> &Keyspace<Shards> {
+    pub fn keyspace(&self) -> &Keyspace<C::KeyspaceShards> {
         &self.keyspace
     }
 
     /// Returns the ongoing [`Migration`] of the WCN cluster.
-    pub fn migration(&self) -> Option<&Migration<Shards>> {
+    pub fn migration(&self) -> Option<&Migration<C::KeyspaceShards>> {
         self.migration.as_ref()
     }
 
@@ -71,7 +67,7 @@ impl<Shards> View<Shards> {
     }
 
     /// Returns [`NodeOperators`] of the WCN cluster.
-    pub fn node_operators(&self) -> &NodeOperators {
+    pub fn node_operators(&self) -> &NodeOperators<NodeOperator<C::Node>> {
         &self.node_operators
     }
 
@@ -91,7 +87,9 @@ impl<Shards> View<Shards> {
         Ok(())
     }
 
-    pub(super) fn require_migration(&self) -> Result<&Migration<Shards>, migration::NotFoundError> {
+    pub(super) fn require_migration(
+        &self,
+    ) -> Result<&Migration<C::KeyspaceShards>, migration::NotFoundError> {
         self.migration.as_ref().ok_or(migration::NotFoundError)
     }
 
@@ -100,9 +98,9 @@ impl<Shards> View<Shards> {
     }
 
     /// Applies the provided [`Event`] to this [`View`].
-    pub async fn apply_event(mut self, event: Event) -> Result<Self, Error>
+    pub async fn apply_event(mut self, cfg: &C, event: Event) -> Result<Self, Error>
     where
-        Keyspace: keyspace::sealed::Calculate<Shards>,
+        Keyspace: keyspace::sealed::Calculate<C::KeyspaceShards>,
     {
         let new_version = event.cluster_version();
 
@@ -120,8 +118,8 @@ impl<Shards> View<Shards> {
             Event::MigrationAborted(evt) => evt.apply(&mut self),
             Event::MaintenanceStarted(evt) => evt.apply(&mut self),
             Event::MaintenanceFinished(evt) => evt.apply(&mut self),
-            Event::NodeOperatorAdded(evt) => evt.apply(&mut self),
-            Event::NodeOperatorUpdated(evt) => evt.apply(&mut self),
+            Event::NodeOperatorAdded(evt) => evt.apply(cfg, &mut self),
+            Event::NodeOperatorUpdated(evt) => evt.apply(cfg, &mut self),
             Event::NodeOperatorRemoved(evt) => evt.apply(&mut self),
             Event::SettingsUpdated(evt) => evt.apply(&mut self),
         }?;
@@ -132,48 +130,35 @@ impl<Shards> View<Shards> {
     }
 }
 
-impl View {
-    pub(super) async fn calculate_keyspace<Shards>(self) -> View<Shards>
+impl<C: Config> View<C> {
+    pub(super) async fn from_sc(
+        cfg: &C,
+        view: smart_contract::ClusterView,
+    ) -> Result<Self, node_operator::DataDeserializationError>
     where
-        Keyspace: keyspace::sealed::Calculate<Shards>,
+        Keyspace: keyspace::sealed::Calculate<C::KeyspaceShards>,
     {
         let (keyspace, migration) = tokio::join!(
-            (*self.keyspace).clone().calculate(),
-            OptionFuture::from(self.migration.map(Migration::calculate_keyspace))
+            view.keyspace.calculate(),
+            OptionFuture::from(view.migration.map(Migration::calculate_keyspace))
         );
 
-        View {
-            node_operators: self.node_operators,
-            ownership: self.ownership,
-            settings: self.settings,
+        Ok(View {
+            node_operators: view.node_operators.try_map(|op| op.deserialize(cfg))?,
+            ownership: view.ownership,
+            settings: view.settings,
             keyspace: Arc::new(keyspace),
             migration,
-            maintenance: self.maintenance,
-            cluster_version: self.cluster_version,
-        }
-    }
-}
-
-impl<Shards> View<Shards, node_operator::SerializedData> {
-    pub(super) fn deserialize(
-        self,
-    ) -> Result<View<Shards>, node_operator::DataDeserializationError> {
-        Ok(View {
-            node_operators: self.node_operators.deserialize()?,
-            ownership: self.ownership,
-            settings: self.settings,
-            keyspace: self.keyspace,
-            migration: self.migration,
-            maintenance: self.maintenance,
-            cluster_version: self.cluster_version,
+            maintenance: view.maintenance,
+            cluster_version: view.cluster_version,
         })
     }
 }
 
 impl migration::Started {
-    async fn apply<Shards>(self, view: &mut View<Shards>) -> Result<()>
+    async fn apply<A: Config>(self, view: &mut View<A>) -> Result<()>
     where
-        Keyspace: keyspace::sealed::Calculate<Shards>,
+        Keyspace: keyspace::sealed::Calculate<A::KeyspaceShards>,
     {
         view.require_no_migration()?;
         view.require_no_maintenance()?;
@@ -192,7 +177,7 @@ impl migration::Started {
 }
 
 impl migration::DataPullCompleted {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<A: Config>(self, view: &mut View<A>) -> Result<()> {
         let idx = view.node_operators.require_idx(&self.operator_id)?;
         view.require_migration()?
             .require_id(self.migration_id)?
@@ -207,7 +192,7 @@ impl migration::DataPullCompleted {
 }
 
 impl migration::Completed {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         let idx = view.node_operators.require_idx(&self.operator_id)?;
         view.require_migration()?
             .require_id(self.migration_id)?
@@ -221,7 +206,7 @@ impl migration::Completed {
 }
 
 impl migration::Aborted {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         view.require_migration()?.require_id(self.migration_id)?;
         view.migration = None;
 
@@ -230,7 +215,7 @@ impl migration::Aborted {
 }
 
 impl maintenance::Started {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         view.require_no_migration()?;
         view.require_no_maintenance()?;
 
@@ -241,7 +226,7 @@ impl maintenance::Started {
 }
 
 impl maintenance::Finished {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         view.require_maintenance()?;
         view.maintenance = None;
 
@@ -250,28 +235,30 @@ impl maintenance::Finished {
 }
 
 impl node_operator::Added {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, cfg: &C, view: &mut View<C>) -> Result<()> {
         view.node_operators()
             .require_not_exists(&self.operator.id)?
             .require_free_slot(self.idx)?;
 
-        view.node_operators.set(self.idx, Some(self.operator));
+        view.node_operators
+            .set(self.idx, Some(self.operator.deserialize(cfg)?));
 
         Ok(())
     }
 }
 
 impl node_operator::Updated {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, cfg: &C, view: &mut View<C>) -> Result<()> {
         let idx = view.node_operators.require_idx(&self.operator.id)?;
-        view.node_operators.set(idx, Some(self.operator));
+        view.node_operators
+            .set(idx, Some(self.operator.deserialize(cfg)?));
 
         Ok(())
     }
 }
 
 impl node_operator::Removed {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         let idx = view.node_operators.require_idx(&self.id)?;
         view.node_operators.set(idx, None);
 
@@ -280,7 +267,7 @@ impl node_operator::Removed {
 }
 
 impl settings::Updated {
-    pub(super) fn apply<S>(self, view: &mut View<S>) -> Result<()> {
+    pub(super) fn apply<C: Config>(self, view: &mut View<C>) -> Result<()> {
         view.settings = self.settings;
 
         Ok(())
@@ -326,6 +313,9 @@ pub enum Error {
 
     #[error(transparent)]
     OperatorSlotOccupied(#[from] node_operators::SlotOccupiedError),
+
+    #[error(transparent)]
+    NodeOperatorDataDeserialization(#[from] node_operator::DataDeserializationError),
 }
 
 /// Result of [`View::apply_event`].
@@ -333,10 +323,4 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Error of fetching [`View`] from a [`smart_contract`].
 #[derive(Debug, thiserror::Error)]
-pub enum FetchError {
-    #[error(transparent)]
-    DataDeserialization(#[from] node_operator::DataDeserializationError),
-
-    #[error("Smart-contract: {0}")]
-    SmartContractRead(#[from] smart_contract::ReadError),
-}
+pub enum FetchError {}

--- a/crates/cluster/tests/integration.rs
+++ b/crates/cluster/tests/integration.rs
@@ -22,6 +22,19 @@ use {
     },
 };
 
+#[derive(Clone, Copy)]
+struct Config {}
+
+impl wcn_cluster::Config for Config {
+    type SmartContract = evm::SmartContract<Signer>;
+    type KeyspaceShards = ();
+    type Node = wcn_cluster::Node;
+
+    fn new_node(&self, addr: SocketAddrV4, peer_id: PeerId) -> Self::Node {
+        wcn_cluster::Node::new(addr, peer_id)
+    }
+}
+
 #[tokio::test]
 async fn test_suite() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
@@ -37,6 +50,8 @@ async fn test_suite() {
         .try_spawn()
         .unwrap();
 
+    let cfg = Config {};
+
     let settings = Settings {
         max_node_operator_data_bytes: 4096,
     };
@@ -50,7 +65,7 @@ async fn test_suite() {
 
     let operators = (1..=5).map(|n| new_node_operator(n, &anvil)).collect();
 
-    let cluster = Cluster::<evm::SmartContract<Signer>>::deploy(&provider, settings, operators)
+    let cluster = Cluster::deploy(cfg, &provider, settings, operators)
         .await
         .unwrap();
 
@@ -106,7 +121,7 @@ async fn test_suite() {
         .unwrap();
 
     let mut operator2 = new_node_operator(2, &anvil);
-    operator2.data.name = node_operator::Name::new("NewName").unwrap();
+    operator2.name = node_operator::Name::new("NewName").unwrap();
     cluster.update_node_operator(operator2).await.unwrap();
 
     cluster
@@ -118,18 +133,14 @@ async fn test_suite() {
 }
 
 fn new_node_operator(n: u8, anvil: &AnvilInstance) -> NodeOperator {
-    let data = node_operator::Data {
+    NodeOperator {
+        id: operator_id(n, anvil),
         name: node_operator::Name::new(format!("Operator{n}")).unwrap(),
         nodes: vec![Node {
             peer_id: PeerId::random(),
             addr: SocketAddrV4::new([127, 0, 0, 1].into(), 40000 + n as u16),
         }],
         clients: vec![],
-    };
-
-    NodeOperator {
-        id: operator_id(n, anvil),
-        data,
     }
 }
 
@@ -154,9 +165,9 @@ async fn connect(
     operator: u8,
     address: smart_contract::Address,
     anvil: &AnvilInstance,
-) -> Cluster<evm::SmartContract<Signer>> {
+) -> Cluster<Config> {
     let provider = provider(new_signer(operator, anvil), anvil).await;
-    Cluster::<evm::SmartContract<Signer>>::connect(&provider, address)
+    Cluster::connect(Config {}, &provider, address)
         .await
         .unwrap()
 }


### PR DESCRIPTION
# Description

Implement a way to inject custom `Node` structure into the `Cluster`.

Current use-case is to be able to put connections there, and by doing so make them automatically managed by the `Cluster`.

## How Has This Been Tested?

Updated integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
