### PR TITLE
feat: migration 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8088,6 +8088,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wcn_migration"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "backoff",
+ "derive-where",
+ "derive_more 1.0.0",
+ "futures",
+ "futures-concurrency",
+ "tap",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wc",
+ "wcn_cluster",
+ "wcn_rpc",
+ "wcn_storage_api2",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "wcn_migration_api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,14 @@ tokio-serde-postcard = { git = "https://github.com/xDarksome/tokio-serde-postcar
 postcard = { version = "1.0", default-features = false }
 itertools = "0.12"
 futures = "0.3"
+futures-concurrency = "7.6"
 backoff = { version = "0.4", features = ["tokio"] }
 tracing = "0.1"
 tokio-stream = "0.1"
 strum = "0.27"
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
+thiserror = "1"
+anyhow = "1"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/cluster/src/node.rs
+++ b/crates/cluster/src/node.rs
@@ -1,6 +1,7 @@
 //! Node within a WCN cluster.
 
 use {
+    derive_more::derive::AsRef,
     libp2p::identity::PeerId,
     serde::{Deserialize, Serialize},
     std::net::SocketAddrV4,
@@ -11,12 +12,13 @@ use {
 /// The IP address is currently being encrypted using a format-preserving
 /// encryption algorithm.
 // TODO: encrypt
-#[derive(Debug, Clone, Copy)]
+#[derive(AsRef, Debug, Clone, Copy)]
 pub struct Node {
     /// [`PeerId`] of the [`Node`].
     ///
     /// Used for authentication. Multiple nodes managed by the same
     /// node operator are allowed to have the same [`PeerId`].
+    #[as_ref]
     pub peer_id: PeerId,
 
     /// [`SocketAddrV4`] of the [`Node`].

--- a/crates/cluster/src/node_operator.rs
+++ b/crates/cluster/src/node_operator.rs
@@ -115,11 +115,23 @@ impl<N> NodeOperator<N> {
         &self.nodes[n % self.nodes.len()]
     }
 
-    /// List of [`Node`]s of the [`NodeOperator`].
+    /// Returns [`Node`]s of this [`NodeOperator`].
     ///
     /// [`NodeOperator`] is guaranteed to always have at least 2 nodes.
     pub fn nodes(&self) -> &[N] {
         &self.nodes
+    }
+
+    /// Returns an [`Iterator`] of [`Node`]s of this [`NodeOperator`].
+    ///
+    /// Iterates over all [`Node`]s starting from an arbitrary position.
+    /// Intended for load balancing purposes.
+    ///
+    /// [`NodeOperator`] is guaranteed to always have at least 2 nodes.
+    pub fn nodes_lb_iter(&self) -> impl Iterator<Item = &N> {
+        let n = self.counter.fetch_add(1, atomic::Ordering::Relaxed);
+        let (left, right) = self.nodes.split_at(n % self.nodes.len());
+        right.iter().chain(left.iter())
     }
 }
 

--- a/crates/cluster/src/node_operators.rs
+++ b/crates/cluster/src/node_operators.rs
@@ -3,6 +3,7 @@
 use {
     crate::{self as cluster, node_operator, Node, NodeOperator},
     indexmap::IndexMap,
+    libp2p::PeerId,
     std::sync::{
         atomic::{self, AtomicUsize},
         Arc,
@@ -56,6 +57,20 @@ impl<N> NodeOperators<N> {
             slots,
             // overflows and starts from `0`
             counter: Arc::new(usize::MAX.into()),
+        })
+    }
+
+    /// Indicates whether any of the [`NodeOperators`] contains a node with the
+    /// provided ID.
+    pub fn contains_node(&self, peer_id: &PeerId) -> bool
+    where
+        N: AsRef<PeerId>,
+    {
+        // TODO: Consider optimizing by building a lookup table.
+        self.slots.iter().any(|opt| {
+            opt.as_ref()
+                .map(|op| op.nodes().iter().any(|node| node.as_ref() == peer_id))
+                .unwrap_or_default()
         })
     }
 

--- a/crates/cluster/src/smart_contract/mod.rs
+++ b/crates/cluster/src/smart_contract/mod.rs
@@ -96,7 +96,8 @@ pub trait Write {
     /// [`migration::Completed`] event MUST be emitted.
     /// Otherwise the data pull MUST be marked as completed for the
     /// [`node::Operator`] and [`migration::DataPullCompleted`] MUST be emitted.
-    fn complete_migration(&self, id: migration::Id) -> impl Future<Output = WriteResult<()>>;
+    fn complete_migration(&self, id: migration::Id)
+        -> impl Future<Output = WriteResult<()>> + Send;
 
     /// Aborts the ongoing data [`migration`] process restoring the WCN cluster
     /// to the original state it had before the migration had started.

--- a/crates/cluster_api/src/rpc/server.rs
+++ b/crates/cluster_api/src/rpc/server.rs
@@ -10,11 +10,11 @@ use {
         Request,
         Response,
         server2::{
-            Connection,
             HandleConnection,
             HandleRequest,
             HandleRpc,
             Inbound,
+            PendingConnection,
             Result,
             Server,
         },
@@ -38,7 +38,9 @@ where
 {
     type Api = super::ClusterApi;
 
-    async fn handle_connection(&self, conn: Connection<'_, Self::Api>) -> Result<()> {
+    async fn handle_connection(&self, conn: PendingConnection<'_, Self::Api>) -> Result<()> {
+        let conn = conn.accept().await?;
+
         conn.handle(&self.rpc_handler, |rpc, handler| async move {
             let handler = handler.as_ref();
 

--- a/crates/migration/Cargo.toml
+++ b/crates/migration/Cargo.toml
@@ -1,33 +1,31 @@
 [package]
-name = "wcn_replication2"
+name = "wcn_migration"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
 [dependencies]
 derive-where = { workspace = true }
+derive_more = { workspace = true }
+anyhow = { workspace = true }
 wc = { workspace = true, features = ["metrics"] }
-xxhash-rust = { workspace = true }
-futures-concurrency = { workspace = true }
+wcn_rpc = { workspace = true }
 storage_api = { package = "wcn_storage_api2", path = "../storage_api2", features = ["rpc_client"] }
 cluster = { package = "wcn_cluster", path = "../cluster" }
+futures-concurrency = { workspace = true }
+backoff = { workspace = true }
 
 futures = "0.3"
 tap = "1.0"
-smallvec = { version = "1.11" }
 tokio = { version = "1", default-features = false }
 tracing = "0.1"
-
-derive_more = { version = "1.0.0", features = ["as_ref"] }
-
-thiserror = "1"
-
-heapless = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false }
 storage_api = { package = "wcn_storage_api2", path = "../storage_api2", features = ["testing"] }
 cluster = { package = "wcn_cluster", path = "../cluster", features = ["testing"] }
+xxhash-rust = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lints]
 workspace = true

--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod manager;
+
+pub use manager::Manager;

--- a/crates/migration/src/manager/mod.rs
+++ b/crates/migration/src/manager/mod.rs
@@ -1,0 +1,406 @@
+use {
+    anyhow::{anyhow, Context, Result},
+    backoff::ExponentialBackoffBuilder,
+    cluster::{
+        keyspace,
+        migration,
+        smart_contract::{self, Write},
+        Cluster,
+        NodeOperator,
+        PeerId,
+    },
+    derive_where::derive_where,
+    futures::{stream, FutureExt as _, Stream, StreamExt, TryFutureExt},
+    futures_concurrency::future::Race,
+    std::{
+        fmt,
+        future::{self, Future},
+        ops::RangeInclusive,
+        pin::pin,
+        sync::Arc,
+        time::Duration,
+    },
+    storage_api::StorageApi,
+    tap::{Pipe as _, TapFallible},
+};
+
+#[cfg(test)]
+mod test;
+
+/// Migration [`Manager`] config.
+pub trait Config:
+    cluster::Config<Node: AsRef<Self::OutboundReplicaConnection> + AsRef<PeerId>> + Clone
+{
+    /// Type of the outbound connections to WCN Replicas.
+    type OutboundReplicaConnection: StorageApi;
+
+    /// Type of the outbound connection to the WCN Database.
+    type OutboundDatabaseConnection: StorageApi + Clone;
+
+    /// Specifies how many shards migration [`Manager`] is allowed to transfer
+    /// at the same time.
+    fn concurrency(&self) -> usize;
+}
+
+/// WCN Migration Manager.
+///
+/// Manages data migration activities of a specific node operator within a WCN
+/// Cluster.
+#[derive(Clone)]
+pub struct Manager<C: Config> {
+    config: Arc<C>,
+    cluster: Cluster<C>,
+    database: C::OutboundDatabaseConnection,
+}
+
+impl<C: Config> Manager<C> {
+    /// Creates a new migration [`Manager`].
+    pub fn new(config: C, cluster: Cluster<C>, database: C::OutboundDatabaseConnection) -> Self {
+        Self {
+            config: Arc::new(config),
+            cluster,
+            database,
+        }
+    }
+
+    /// Establishes a new [`InboundConnection`].
+    ///
+    /// Returns `None` if the peer is not authorized to use this migration
+    /// [`Manager`].
+    pub fn new_inbound_connection(&self, peer_id: PeerId) -> Option<InboundConnection<C>> {
+        if !self.cluster.contains_node(&peer_id) {
+            return None;
+        }
+
+        Some(InboundConnection {
+            _peer_id: peer_id,
+            manager: self.clone(),
+        })
+    }
+
+    /// Runs a task managing all data migration related activities of a node
+    /// operator.
+    ///
+    /// There should only be a single such task running at any point in time
+    /// across all node operator nodes / infrastructure services.
+    pub fn run(&self) -> impl Future<Output = ()> + Send
+    where
+        C: Config<KeyspaceShards = keyspace::Shards, SmartContract: smart_contract::Write>,
+    {
+        Task {
+            manager: self.clone(),
+            state: State::Idle,
+        }
+        .run()
+    }
+}
+
+impl<C: Config> storage_api::Factory<PeerId> for Manager<C> {
+    type StorageApi = InboundConnection<C>;
+
+    fn new_storage_api(&self, peer_id: PeerId) -> storage_api::Result<Self::StorageApi> {
+        self.new_inbound_connection(peer_id)
+            .ok_or_else(storage_api::Error::unauthorized)
+    }
+}
+
+/// Inbound connection to the local migration [`Manager`] from a remote peer.
+#[derive_where(Clone)]
+pub struct InboundConnection<C: Config> {
+    _peer_id: PeerId,
+    manager: Manager<C>,
+}
+
+impl<C: Config> StorageApi for InboundConnection<C> {
+    async fn execute_ref(
+        &self,
+        _operation: &storage_api::Operation<'_>,
+    ) -> storage_api::Result<storage_api::operation::Output> {
+        // Migration manager do not handle regular storage operations.
+        Err(storage_api::Error::unauthorized())
+    }
+
+    async fn read_data(
+        &self,
+        keyrange: RangeInclusive<u64>,
+        keyspace_version: u64,
+    ) -> storage_api::Result<impl Stream<Item = storage_api::Result<storage_api::DataItem>> + Send>
+    {
+        let manager = &self.manager;
+
+        if !manager.cluster.validate_keyspace_version(keyspace_version) {
+            return Err(storage_api::Error::keyspace_version_mismatch());
+        }
+
+        manager.database.read_data(keyrange, keyspace_version).await
+    }
+}
+
+struct Task<C: Config> {
+    manager: Manager<C>,
+    state: State,
+}
+
+impl<C> Task<C>
+where
+    C: Config<SmartContract: smart_contract::Write, KeyspaceShards = keyspace::Shards>,
+{
+    async fn run(self) {
+        let mut watch = self.cluster().watch();
+        let mut state_fut = pin!(self.state_future(State::Idle));
+
+        loop {
+            let cluster_update_fut = watch.cluster_updated().map(|_| Event::ClusterUpdate);
+
+            let new_state = match (cluster_update_fut, &mut state_fut).race().await {
+                Event::ClusterUpdate => self.sync_state(),
+                Event::StateTransition(state) => Some(state),
+            };
+
+            if let Some(state) = new_state {
+                tracing::info!(" -> {state:?}");
+                state_fut.set(self.state_future(state));
+            }
+        }
+    }
+
+    fn sync_state(&self) -> Option<State> {
+        let local_migration_id = self.state.migration_id();
+        let cluster_migration_id = self.cluster().view().migration().map(|mig| mig.id());
+
+        match (local_migration_id, cluster_migration_id) {
+            // State is up to date.
+            (Some(a), Some(b)) if a == b => None,
+            (None, None) => None,
+
+            // We are doing something, but cluster no longer has an ongoing migration.
+            // Drop everything and go back to `Idle`.
+            (Some(_), None) => Some(State::Idle),
+
+            // We are either `Idle` or handling a wrong migration.
+            // Kick-off a new migration process.
+            (_, Some(id)) => Some(State::TransferringData(id)),
+        }
+    }
+
+    async fn state_future(&self, state: State) -> Event {
+        retry(|| async {
+            match state {
+                State::TransferringData(migration_id) => self
+                    .transfer_data(migration_id)
+                    .await
+                    .context("Manager::transfer_data"),
+                State::CompletingMigration(migration_id) => self
+                    .complete_migration(migration_id)
+                    .await
+                    .context("Manager::complete_migration"),
+                State::AwaitingMigrationCompletion(migration_id) => self
+                    .await_migration_completion(migration_id)
+                    .await
+                    .context("Manager::await_migration_completion"),
+                State::Idle => future::pending().await,
+            }
+            .tap_err(|err| tracing::error!(%err))
+        })
+        .map(Event::StateTransition)
+        .await
+    }
+
+    async fn transfer_data(&self, migration_id: migration::Id) -> Result<State> {
+        let cluster_view = self.cluster().view();
+        let keyspace_version = cluster_view
+            .migration()
+            .ok_or_else(|| anyhow!("Missing migration"))?
+            .keyspace()
+            .version();
+
+        let primary_shards = cluster_view.primary_keyspace_shards();
+        let secondary_shards = cluster_view
+            .secondary_keyspace_shards()
+            .ok_or_else(|| anyhow!("Missing secondary keyspace shards"))?;
+
+        let operator_id = self.cluster().smart_contract().signer().address();
+
+        let replica_idx = |shard: &keyspace::Shard<&NodeOperator<_>>| {
+            shard
+                .replica_set()
+                .iter()
+                .position(|op| &op.id == operator_id)
+        };
+
+        primary_shards
+            .zip(secondary_shards)
+            .filter_map(|((shard_id, primary), (_, secondary))| {
+                // If operator is not in the new replica set skip this shard.
+                let secondary_idx = replica_idx(&secondary)?;
+
+                // Also skip if operator is in the old replica set. Meaning that it's in both,
+                // so we don't need to transfer any data.
+                let None = replica_idx(&primary) else {
+                    return None;
+                };
+
+                // Pull data only from the operator previously occupying the same replica index
+                // to guarantee consistency.
+                // TODO: We should have a way to override this behaviour for special
+                // circumstances, for example if a node operator is completely dead and we are
+                // forcefully removing it.
+                let source = primary.replica_set()[secondary_idx];
+
+                Some((shard_id, source))
+            })
+            .pipe(stream::iter)
+            .for_each_concurrent(Some(self.manager.config.concurrency()), |(shard_id, source)| {
+                retry(move || {
+                    // TODO: This log may spam in case of an outage, figure out how to rate limit it.
+                    self.transfer_shard(shard_id, source, keyspace_version)
+                        .map_err(move |err| tracing::warn!(?err, %shard_id, source = %source.id, "Failed to transfer shard"))
+                })
+            })
+            .await;
+
+        Ok(State::CompletingMigration(migration_id))
+    }
+
+    async fn transfer_shard(
+        &self,
+        shard_id: keyspace::ShardId,
+        source_operator: &NodeOperator<C::Node>,
+        keyspace_version: u64,
+    ) -> storage_api::Result<()> {
+        use storage_api::ErrorKind;
+
+        let keyrange = keyspace::keyrange(shard_id);
+
+        let mut res = Err(storage_api::Error::internal());
+
+        // Retry transport errors using different nodes.
+        for node in source_operator.nodes_lb_iter() {
+            let conn: &C::OutboundReplicaConnection = node.as_ref();
+            res = conn.read_data(keyrange.clone(), keyspace_version).await;
+
+            if matches!(&res, Err(err) if err.kind() == ErrorKind::Transport) {
+                continue;
+            };
+
+            return self.database().write_data(res?).await;
+        }
+
+        res.map(drop)
+    }
+
+    async fn complete_migration(&self, migration_id: migration::Id) -> Result<State> {
+        use cluster::CompleteMigrationError as Error;
+
+        match self.cluster().complete_migration(migration_id).await {
+            Ok(_) => {}
+            // This error is theoretically possible under an extreme race condition when something
+            // else completes the migration.
+            Err(Error::OperatorNotPulling(_)) => {
+                return Ok(State::AwaitingMigrationCompletion(migration_id))
+            }
+            Err(
+                err @ (Error::UnknownOperator(_)
+                | Error::NoMigration(_)
+                | Error::WrongMigrationId(_)
+                | Error::SmartContract(_)),
+            ) => return Err(err.into()),
+        };
+
+        let operator_id = self.cluster().smart_contract().signer().address();
+
+        // Wait until our commit to SC is observable.
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if !self
+                    .cluster()
+                    .using_view(|view| view.is_pulling(operator_id))
+                {
+                    return State::AwaitingMigrationCompletion(migration_id);
+                }
+
+                tokio::time::sleep(Duration::from_secs(10)).await
+            }
+        })
+        .await
+        .context("Waiting for is_pulling == false")
+    }
+
+    async fn await_migration_completion(&self, migration_id: migration::Id) -> Result<State> {
+        let operator_id = self.cluster().smart_contract().signer().address();
+
+        loop {
+            // We have completed the migration already, but somehow the cluster shows again
+            // that we are pulling.
+            // It indicates that our commit to the SC didn't go through somehow, probably
+            // because of a chain reorg.
+            //
+            // Go back to `CompletingMigration` state.
+            if self
+                .cluster()
+                .using_view(|view| view.is_pulling(operator_id))
+            {
+                tracing::warn!("Going back to `State::CompletingMigration`");
+                return Ok(State::CompletingMigration(migration_id));
+            }
+
+            // Just loop enlessly.
+            //
+            // The task will be canceled once we receive `ClusterUpdate` and there's no
+            // longer an ongoing migration within the cluster.
+            tokio::time::sleep(Duration::from_secs(10)).await
+        }
+    }
+
+    fn cluster(&self) -> &Cluster<C> {
+        &self.manager.cluster
+    }
+
+    fn database(&self) -> &C::OutboundDatabaseConnection {
+        &self.manager.database
+    }
+}
+
+enum Event {
+    ClusterUpdate,
+    StateTransition(State),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum State {
+    TransferringData(migration::Id),
+    CompletingMigration(migration::Id),
+    AwaitingMigrationCompletion(migration::Id),
+    Idle,
+}
+
+impl State {
+    fn migration_id(self) -> Option<migration::Id> {
+        Some(match self {
+            State::TransferringData(migration_id) => migration_id,
+            State::CompletingMigration(migration_id) => migration_id,
+            State::AwaitingMigrationCompletion(migration_id) => migration_id,
+            State::Idle => return None,
+        })
+    }
+}
+
+async fn retry<Ok, E, F, Fut>(f: F) -> Ok
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<Ok, E>>,
+    E: fmt::Debug,
+{
+    let backoff = ExponentialBackoffBuilder::new()
+        .with_randomization_factor(0.5)
+        .with_initial_interval(Duration::from_secs(1))
+        .with_max_interval(Duration::from_secs(60))
+        .with_max_elapsed_time(None)
+        .build();
+
+    let f = || async { f().await.map_err(backoff::Error::transient) };
+
+    // NOTE(unwrap): we use `.with_max_elapsed_time(None)`, the error won't be
+    // emitted.
+    backoff::future::retry(backoff, f).await.unwrap()
+}

--- a/crates/migration/src/manager/test.rs
+++ b/crates/migration/src/manager/test.rs
@@ -1,0 +1,200 @@
+use {
+    crate::Manager,
+    cluster::{
+        keyspace::{self},
+        migration,
+        node_operator,
+        smart_contract::{self, testing::FakeSmartContract, Read},
+        Cluster,
+    },
+    derive_more::derive::AsRef,
+    futures::{stream, FutureExt as _, StreamExt},
+    std::{collections::HashSet, hash::BuildHasher as _, time::Duration},
+    storage_api::{operation, testing::FakeStorage, Operation, Record, RecordVersion, StorageApi},
+    tracing_subscriber::EnvFilter,
+    wcn_rpc::PeerId,
+    xxhash_rust::xxh3::Xxh3Builder,
+};
+
+#[derive(Clone, Default)]
+struct Config {
+    smart_contract_registry: smart_contract::testing::FakeRegistry,
+    storage_registy: storage_api::testing::FakeRegistry<node_operator::Id>,
+}
+
+impl cluster::Config for Config {
+    type SmartContract = FakeSmartContract;
+    type KeyspaceShards = keyspace::Shards;
+    type Node = Node;
+
+    fn new_node(&self, operator_id: node_operator::Id, node: cluster::Node) -> Node {
+        Node {
+            peer_id: node.peer_id,
+            storage: self.storage_registy.get(operator_id),
+        }
+    }
+}
+
+impl super::Config for Config {
+    type OutboundReplicaConnection = FakeStorage;
+    type OutboundDatabaseConnection = FakeStorage;
+
+    fn concurrency(&self) -> usize {
+        100
+    }
+}
+
+#[derive(AsRef, Clone)]
+struct Node {
+    #[as_ref]
+    peer_id: PeerId,
+
+    #[as_ref]
+    storage: FakeStorage,
+}
+
+#[tokio::test]
+async fn transfers_data_and_writes_to_smart_contract() {
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::INFO)
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let namespace = "0x14Cb1e6fb683A83455cA283e10f4959740A49ed7/0"
+        .parse()
+        .unwrap();
+
+    let cfg = Config::default();
+
+    let cluster = Cluster::deploy(
+        cfg.clone(),
+        &cfg.smart_contract_registry
+            .deployer(smart_contract::testing::signer(42)),
+        cluster::Settings {
+            max_node_operator_data_bytes: 1024,
+        },
+        (0..8)
+            .map(|idx| cluster::testing::node_operator(idx as u8))
+            .collect(),
+    )
+    .await
+    .unwrap();
+
+    let new_operator = cluster::testing::node_operator(10);
+
+    cluster
+        .add_node_operator(new_operator.clone())
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    cluster
+        .start_migration(migration::Plan {
+            remove: HashSet::new(),
+            add: [new_operator.id].into_iter().collect(),
+            replication_strategy: keyspace::ReplicationStrategy::UniformDistribution,
+        })
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let cluster_view = cluster.view();
+
+    let mut expect_get_ops = Vec::new();
+
+    for i in 0..100000 {
+        let key = i.to_string().into_bytes();
+        let hash = key_hash(&key);
+
+        let set_op = |value| operation::Set {
+            namespace,
+            key: key.clone(),
+            record: Record {
+                value: format!("{value}{i}").into_bytes(),
+                expiration: Duration::from_secs(60).into(),
+                version: RecordVersion::now(),
+            },
+            keyspace_version: Some(1),
+        };
+
+        let new_operator_replica_idx = cluster_view
+            .secondary_replica_set(hash)
+            .unwrap()
+            .iter()
+            .position(|op| op.id == new_operator.id);
+
+        let correct_data = set_op("Correct");
+        let wrong_data = set_op("Wrong");
+
+        for (idx, replica) in cluster_view
+            .primary_replica_set(hash)
+            .into_iter()
+            .enumerate()
+        {
+            // Put wrong data into shards that shouldn't be transferred and into operators
+            // that are not the primary data transfer source.
+            cfg.storage_registy
+                .get(replica.id)
+                .execute(
+                    operation::Owned::Set(if Some(idx) == new_operator_replica_idx {
+                        correct_data.clone()
+                    } else {
+                        wrong_data.clone()
+                    })
+                    .into(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let get_op = operation::Get {
+            namespace,
+            key,
+            keyspace_version: Some(1),
+        };
+
+        let expected_record = if new_operator_replica_idx.is_some() {
+            Some(correct_data.record.clone())
+        } else {
+            None
+        };
+        expect_get_ops.push((get_op, operation::Output::Record(expected_record)))
+    }
+
+    let new_operator_storage = cfg.storage_registy.get(new_operator.id);
+    let new_operator_cluster = Cluster::connect(
+        cfg.clone(),
+        &cfg.smart_contract_registry
+            .connector(smart_contract::testing::signer(10)),
+        cluster.smart_contract().address(),
+    )
+    .await
+    .unwrap();
+
+    let manager = Manager::new(
+        cfg.clone(),
+        new_operator_cluster,
+        new_operator_storage.clone(),
+    );
+
+    tokio::spawn(manager.run());
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    stream::iter(expect_get_ops)
+        .for_each_concurrent(100, |(get, expected_out)| {
+            new_operator_storage
+                .execute(Operation::Owned(operation::Owned::Get(get)))
+                .map(|res| assert_eq!(res, Ok(expected_out)))
+        })
+        .await;
+
+    assert!(!cluster.view().is_pulling(&new_operator.id));
+}
+
+fn key_hash(bytes: &[u8]) -> u64 {
+    static HASHER: Xxh3Builder = Xxh3Builder::new();
+
+    HASHER.hash_one(bytes)
+}

--- a/crates/replication2/src/replica.rs
+++ b/crates/replication2/src/replica.rs
@@ -1,40 +1,76 @@
 use {
-    cluster::Cluster,
+    cluster::{Cluster, PeerId},
     derive_where::derive_where,
     futures::Stream,
-    std::ops::RangeInclusive,
+    std::{ops::RangeInclusive, sync::Arc},
     storage_api::{operation, DataItem, Error, Operation, Result, StorageApi},
 };
 
-#[derive_where(Clone)]
-pub struct Replica<C: cluster::Config, DB: Clone> {
-    _cluster: Cluster<C>,
-    database: DB,
+/// [`Replica`] config.
+pub trait Config: cluster::Config {
+    /// Type of the outbound connection to the WCN Database.
+    type OutboundDatabaseConnection: StorageApi + Clone;
 }
 
-impl<C, DB> Replica<C, DB>
-where
-    C: cluster::Config,
-    DB: StorageApi + Clone,
-{
+#[derive_where(Clone)]
+pub struct Replica<C: Config> {
+    _config: Arc<C>,
+    cluster: Cluster<C>,
+    database: C::OutboundDatabaseConnection,
+}
+
+impl<C: Config> Replica<C> {
     /// Creates a new [`Replica`].
-    pub fn new(cluster: Cluster<C>, database: DB) -> Self {
+    pub fn new(
+        config: Arc<C>,
+        cluster: Cluster<C>,
+        database: C::OutboundDatabaseConnection,
+    ) -> Self {
         Self {
-            _cluster: cluster,
+            _config: config,
+            cluster,
             database,
         }
     }
+
+    /// Establishes a new [`InboundConnection`].
+    ///
+    /// Returns `None` if the peer is not authorized to use this migration
+    /// [`Replica`].
+    pub fn new_inbound_connection(&self, peer_id: PeerId) -> Option<InboundConnection<C>> {
+        if !self.cluster.contains_node(&peer_id) {
+            return None;
+        }
+
+        Some(InboundConnection {
+            _peer_id: peer_id,
+            replica: self.clone(),
+        })
+    }
 }
 
-impl<C, DB> StorageApi for Replica<C, DB>
-where
-    C: cluster::Config,
-    DB: StorageApi + Clone,
-{
+/// Inbound connection to the local [`Replica`] from a remote peer.
+#[derive_where(Clone)]
+pub struct InboundConnection<C: Config> {
+    _peer_id: PeerId,
+    replica: Replica<C>,
+}
+
+impl<C: Config> storage_api::Factory<PeerId> for Replica<C> {
+    type StorageApi = InboundConnection<C>;
+
+    fn new_storage_api(&self, peer_id: PeerId) -> storage_api::Result<Self::StorageApi> {
+        self.new_inbound_connection(peer_id)
+            .ok_or_else(storage_api::Error::unauthorized)
+    }
+}
+
+impl<C: Config> StorageApi for InboundConnection<C> {
     async fn execute_ref(&self, operation: &Operation<'_>) -> Result<operation::Output> {
         // TODO: once we add signatures to write operations check them here
 
-        self.database
+        self.replica
+            .database
             .execute_ref(operation)
             .await
             .map_err(|_| Error::new(storage_api::ErrorKind::Internal))
@@ -45,6 +81,9 @@ where
         keyrange: RangeInclusive<u64>,
         keyspace_version: u64,
     ) -> storage_api::Result<impl Stream<Item = storage_api::Result<DataItem>> + Send> {
-        self.database.read_data(keyrange, keyspace_version).await
+        self.replica
+            .database
+            .read_data(keyrange, keyspace_version)
+            .await
     }
 }

--- a/crates/sharding/src/lib.rs
+++ b/crates/sharding/src/lib.rs
@@ -10,7 +10,7 @@ pub mod testing;
 
 /// Identifier of a shard.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ShardId(u16);
+pub struct ShardId(pub u16);
 
 impl ShardId {
     /// Creates a [`ShardId`] identifying the shard resposible for the given

--- a/crates/storage_api2/src/lib.rs
+++ b/crates/storage_api2/src/lib.rs
@@ -113,6 +113,26 @@ pub trait StorageApi: Send + Sync + 'static {
     }
 }
 
+/// [`StorageApi`] factory.
+pub trait Factory<Args>: Clone + Send + Sync + 'static {
+    /// [`StorageApi`] types produced by this factory.
+    type StorageApi: StorageApi + Clone;
+
+    /// Creates a new [`StorageApi`].
+    fn new_storage_api(&self, args: Args) -> Result<Self::StorageApi>;
+}
+
+impl<Args, S> Factory<Args> for S
+where
+    S: StorageApi + Clone,
+{
+    type StorageApi = Self;
+
+    fn new_storage_api(&self, _args: Args) -> Result<Self::StorageApi> {
+        Ok(self.clone())
+    }
+}
+
 /// [`StorageApi`] callback for returning borrowed [`operation::Output`]s.
 pub trait Callback: Send {
     type Error: Send + 'static;
@@ -391,6 +411,11 @@ impl Error {
     /// Creates a new [`Error`] with [`ErrorKind::Unauthorized`].
     pub const fn unauthorized() -> Self {
         Self::new(ErrorKind::Unauthorized)
+    }
+
+    /// Creates a new [`Error`] with [`ErrorKind::KeyspaceVersionMismatch`].
+    pub const fn keyspace_version_mismatch() -> Self {
+        Self::new(ErrorKind::KeyspaceVersionMismatch)
     }
 
     /// Creates a new [`Error`] with [`ErrorKind::Internal`].

--- a/crates/storage_api2/src/rpc/mod.rs
+++ b/crates/storage_api2/src/rpc/mod.rs
@@ -51,6 +51,9 @@ mod api_kind {
     pub struct Replica;
 
     #[derive(Clone, Copy, Debug)]
+    pub struct MigrationManager;
+
+    #[derive(Clone, Copy, Debug)]
     pub struct Database;
 }
 
@@ -65,6 +68,13 @@ pub type ReplicaApi = Api<api_kind::Replica>;
 
 impl wcn_rpc::Api for ReplicaApi {
     const NAME: ApiName = ApiName::new("Replica");
+    type RpcId = Id;
+}
+
+pub type MigrationManagerApi = Api<api_kind::MigrationManager>;
+
+impl wcn_rpc::Api for MigrationManagerApi {
+    const NAME: ApiName = ApiName::new("MigrationManager");
     type RpcId = Id;
 }
 


### PR DESCRIPTION
# Description

Machinery for managing WCN 2.0 migrations.

Additionally:
- add authorization to `replication::Replica` 

## How Has This Been Tested?

Unit

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
